### PR TITLE
fix minor typo in readme and watson 102 lab

### DIFF
--- a/Watson/102.md
+++ b/Watson/102.md
@@ -267,7 +267,7 @@ Then, add an image with the following properties:
 
 - **Source URL:** https://img.money.com/2020/10/checking-vs-savings-revised-1.gif
 - **Alt text:** Checking versus savings
-- **Title:** Chhecking versus savings
+- **Title:** Checking versus savings
 - **Description:** Learn more about checking, savings, and other account types on our website!
 
 Verify that your screen looks like the image below, and click **Apply**:

--- a/Watson/README.md
+++ b/Watson/README.md
@@ -9,7 +9,7 @@ After completing these labs in a workshop session, you'll be able to earn the [W
 - IBM id
 - IBM Cloud account
 - Recommended: Level 1 and Level 2 material for the [Watson Assistant Sales Foundation badge](https://www.credly.com/org/ibm/badge/watson-assistant-sales-foundation.1).
-- Currently, the workships require additional content which introduces them in an in-person workshop setting and provides configuration detail that's not found directly in the repo. This content may be added at a later date.
+- Currently, the workshops require additional content which introduces them in an in-person workshop setting and provides configuration detail that's not found directly in the repo. This content may be added at a later date.
 
 ## Labs
 


### PR DESCRIPTION
Fix minor typos in two files.
1) README.md
2) Watson assistant 102 lab

![image](https://user-images.githubusercontent.com/94190118/226614452-535c41b8-f27e-4408-9b84-37f02f38e52b.png)
![image](https://user-images.githubusercontent.com/94190118/226614492-85748de3-9f3d-49ac-b8d8-ef6f346de10d.png)
