### PR TITLE
Remove prefixed path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # VAD VAR Workshop Docs
 
-This repo contains content for IBM Ecosystem partners (primarily our Value-Added Distributors and Value-Added Resellers) to build experiential sales skills with various IBM products.
+This repo contains the site code for IBM Ecosystem partners content (primarily our Value-Added Distributors and Value-Added Resellers) to build experiential sales skills with various IBM products.
+
+To see the content itself visit: https://vest.buildlab.cloud/
 
 Built using:
 
@@ -54,7 +56,7 @@ This creates the actual static pages of the site under the `/public` directory a
 npm run serve
 ```
 
-Using the supplied `serve` command will start host the site locally at http://localhost:9000/VAD-VAR-Workshop/ (Note the prefixed path).
+Using the supplied `serve` command will start host the site locally at http://localhost:9000.
 
 ### Deployment
 

--- a/gatsby-config.mjs
+++ b/gatsby-config.mjs
@@ -14,7 +14,6 @@ const isDev = NODE_ENV === 'development';
 const optimizeImages = IMAGE_OPTIMIZATION === 'true';
 
 const config = {
-  pathPrefix: '/VAD-VAR-Workshop',
   siteMetadata: {
     title: `VAD-VAR`,
     description: 'Experiential Selling Workshops for IBM Ecosystem Partners',

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   ],
   "scripts": {
     "dev": "gatsby develop",
-    "build": "gatsby build --prefix-paths",
-    "serve": "gatsby serve --prefix-paths",
+    "build": "gatsby build",
+    "serve": "gatsby serve",
     "clean": "gatsby clean",
     "typecheck": "tsc --noEmit",
     "lint": "eslint . --ext js,md,mdx,ts,tsx,mjs",

--- a/src/components/replacements/SmartLink.tsx
+++ b/src/components/replacements/SmartLink.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@reach/router';
+import { Link as GatsbyLink } from 'gatsby';
 import React from 'react';
 import { Launch } from '@carbon/react/icons';
 import { Link as CarbonLink } from '@carbon/react';
@@ -11,7 +11,7 @@ const SmartLink = (props: React.AnchorHTMLAttributes<HTMLAnchorElement>) => {
   const isInternal =
     !href.startsWith('//') && !href.startsWith('http') && !href.startsWith('mailto:');
 
-  if (isInternal) return <Link to={href}>{children}</Link>;
+  if (isInternal) return <GatsbyLink to={href}>{children}</GatsbyLink>;
 
   return (
     <CarbonLink href={href} target='_blank' rel='noreferrer'>


### PR DESCRIPTION
Content changes:

- N/A

Code changes:

- Remove prefixed path from `gatsby-config`
- Use Gatsby link component again in `Smart Link`
- Remove `--prefix-path` option from scripts in `package.json`