### PR TITLE
Testing and fix typos qradar 106

### DIFF
--- a/content/QRadar-SIEM/106.md
+++ b/content/QRadar-SIEM/106.md
@@ -14,7 +14,7 @@ In these exercises, you will develop an anomaly detection rule of type *Anomaly*
 
 ## Preparing for the Anomaly Rule
 
-For each anomaly detection rule, a grouped search provides the time series data the Anomaly Detection Engine (ADE) will use to detect any statistical deviations. In this exercise, you create a grouped search. To confirm, that your search works as intended, you feed sample data to QRadar SIEM. After QRadar SIEM has discovered the log source type of the sample data, it automatically creates a log source.
+For each anomaly detection rule, a grouped search provides the time series data the Anomaly Detection Engine (ADE) will use to detect any statistical deviations. In this exercise, you create a grouped search. To confirm that your search works as intended, you feed sample data to QRadar SIEM. After QRadar SIEM has discovered the log source type of the sample data, it automatically creates a log source.
 
 > If you are using the Wireguard VPN configured in **101: QRadar Demo Setup** to access the demo environment then you can perform the following activities from your workstation. If you have not configured VPN access you can perform the activities from the jump server.
 
@@ -28,7 +28,7 @@ QRadar SIEM needs to process sample data to create the example used in this lab 
  ssh root@172.16.60.10
  ```
 
- The password is: Q1d3m0
+ The password is: `Q1d3m0`
 
 2. Feed the prepared syslog message to QRadar:
 
@@ -103,7 +103,7 @@ Anomaly detection rules test the results of a grouped event or flow search.
 
  ![](/images/106/image12.png)
 
-1. To run the new search, click one of the **Search** buttons.
+1. To run the new search, click on the **Search** button.
 
  As a result, the Log Activity tab displays the search result.
 
@@ -143,9 +143,9 @@ After creating an anomaly rule in this exercise, you will verify it in the next 
 
 1. Bring the terminal window to the front.
 
- The terminal window displays the output of script that feeds sample data to QRadar SIEM.
+   The terminal window displays the output of script that feeds sample data to QRadar SIEM.
 
-1. Confirm that the script has finished.
+1. Confirm that the script has finished. If it has not, type **control-c** (or **Ctrl-c** depending on your keyboard)
 
 1. Do not close the terminal window.
 
@@ -263,7 +263,7 @@ To have an offense created for the unusual privilege escalations that the anomal
 
 2. The Rule Wizard has already prepared the Rule Response. For this example, do not make any changes.
 
-3. To observe, that the offense can only be indexed on Event Name, open the **Index offense based on** drop-down list.
+3. To observe that the offense can only be indexed on Event Name, open the **Index offense based on** drop-down list.
 
  ![](/images/106/image26.jpg)
 
@@ -321,7 +321,7 @@ The average of the interval with the spike deviates by a higher percentage than 
 
 4. Optionally, click **Anomaly** in the toolbar.
 
- A separate window opens with the results of the search that your anomaly rule uses.
+   A separate window opens with the results of the search that your anomaly rule uses.
 
 5. Review the search result and close the browser window to get back to the main window of the QRadar console.
 
@@ -337,4 +337,4 @@ The average of the interval with the spike deviates by a higher percentage than 
 
 ## Summary
 
-You have completed this lab and have successfully completed this lab by creating and verify an anomaly rule in QRadar.
+You have successfully completed this lab by creating and verifing an anomaly rule in QRadar.


### PR DESCRIPTION
Content changes:

- fixes for grammar and style
- add Ctrl-C command to terminate spike generating shell script before configuring anomaly rule