### PR TITLE
chore(watsonx): expose data and assistant labs

### DIFF
--- a/content/Watsonx/README.md
+++ b/content/Watsonx/README.md
@@ -7,11 +7,9 @@ toc: false
 
 This workshop includes hands on labs designed to provide practical experience with IBM's data and AI platform, watsonx.
 
-## Labs (coming soon)
+## Labs
 
-### [watsonx.ai](/watsonx/watsonxai)
-
-
+### watsonx.ai - coming soon
 ### [watsonx.data](/watsonx/watsonxdata)
-
-### [watsonx code assistant](/watsonx/codeassistant)
+### [watsonx Assistant](/watsonx/assistant)
+### watsonx code assistant - coming soon

--- a/gatsby-config.mjs
+++ b/gatsby-config.mjs
@@ -12,7 +12,7 @@ const require = createRequire(import.meta.url);
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const underConstrunction = ['**/Watsonx'];
+const underConstrunction = ['**/Watsonx/CodeAssistant', '**/Watsonx/WatsonxAI'];
 
 const { NODE_ENV, LOCAL_IMAGES } = process.env;
 


### PR DESCRIPTION
Exposing data and assistant labs.  We have folks outside our team starting to review the data labs. 
