### PR TITLE
chore(jupyterhub): temporarily remove hub reference

### DIFF
--- a/content/Watsonx/WatsonxAI/105.md
+++ b/content/Watsonx/WatsonxAI/105.md
@@ -18,12 +18,6 @@ The first part starts with a gentle introduction to some langchain capabilities,
 
 ## Labs
 
-There are 2 ways to run these labs.
-1. Locally on your laptop - Requires Python to be installed and slightly more technical expertise, or,
-2. On our shared JupterHub instance
-
-Choose the option below that suits you best.
-
 ### Run the labs locally on your laptop:
 
 #### Prerequisites
@@ -61,10 +55,6 @@ Choose the option below that suits you best.
    - `PROJECT_ID` can be found under [watsonx projects](https://dataplatform.cloud.ibm.com/projects/?context=wx) under the project manage tab. The id is also part of the URL: `https://dataplatform.cloud.ibm.com/projects/<project-id>/manage/general?context=wx`
 
 After finishing the prerequisites, complete the labs with the jupyter notebooks below.
-
-### Run the labs in the Watsonx web interface:
-
-For this option, the instructor will share login URL and credentials with you to log into JupyterHub. This will provide you with your own instance with notebooks that can be run to complete the labs.
 
 
 ### Notebooks: 


### PR DESCRIPTION
- Temporarily revert Langchain labs while JupyterHub issues are ironed out. 
