### PR TITLE
re-add jupyterhub lab instructions

### DIFF
--- a/content/Watsonx/WatsonxAI/105.md
+++ b/content/Watsonx/WatsonxAI/105.md
@@ -16,11 +16,14 @@ Today, we will be using Langchain with [watsonx.ai](https://www.ibm.com/products
 
 The first part starts with a gentle introduction to some langchain capabilities, including how to initialize a model, change inference parameters, use templates, chains, and load documents. We will then move on to summarization of large amounts of text, which includes more moving parts.
 
-## Labs
+## There are 2 ways you can run these Langchain labs:
+1. Locally on your laptop (requires slightly more technical expertise)
+2. In our shared JupyterHub environment 
 
-### Run the labs locally on your laptop:
 
-#### Prerequisites
+## Run the labs locally on your laptop:
+
+### Prerequisites
 1. Make sure Python >= 3.11 is installed. (`python3 --version`)
 2. In your terminal, navigate to a folder where you want to work, and create a Virtual Environment: `python3 -m venv langchain` Note: you might want to create this in a folder where there aren't any other projects or version control to avoid conflicts.
 3. Activate the environment:
@@ -56,6 +59,8 @@ The first part starts with a gentle introduction to some langchain capabilities,
 
 After finishing the prerequisites, complete the labs with the jupyter notebooks below.
 
+## Run the labs in JupyterHub:
+Your instructor will provide the URL and login information for the hub. Just log in and follow the instructions in the notebooks. They are the same notebooks as listed below. If needed, follow step 7 above to get the values for environment variables.
 
 ### Notebooks: 
 

--- a/content/Watsonx/WatsonxAI/105/langchain-intro.ipynb
+++ b/content/Watsonx/WatsonxAI/105/langchain-intro.ipynb
@@ -234,7 +234,7 @@
    "metadata": {},
    "source": [
     "## 4. Easy Loading of Documents Using Lang Chain\n",
-    "LangChain makes it easy to extract passages from documents so that you can answer questions based on your document's content. First download the example PDF file to your working folder: [what is generative ai.pdf](https://github.com/ibm-build-lab/VAD-VAR-Workshop/blob/main/content/Watsonx/WatsonxAI/105/what%20is%20generative%20ai.pdf)"
+    "LangChain makes it easy to extract passages from documents so that you can answer questions based on your document's content. First download the example PDF file to your working folder: [what-is-generative-ai.pdf](https://github.com/ibm-build-lab/VAD-VAR-Workshop/blob/main/content/Watsonx/WatsonxAI/105/what-is-generative-ai.pdf)"
    ]
   },
   {
@@ -245,7 +245,7 @@
    "outputs": [],
    "source": [
     "# Load PDF document\n",
-    "pdf='what is generative ai.pdf'\n",
+    "pdf='what-is-generative-ai.pdf'\n",
     "loaders = [PyPDFLoader(pdf)]\n",
     "print(\"Done.\")\n"
    ]


### PR DESCRIPTION
Just re-adding langchain lab option to run jupyter notebook. 

NOTE: The hub is still not deployed properly on Code Engine, for NYC I will attempt to run it on my laptop and provide an NGROK tunnel link. I tested it with 40 concurrent docker containers without issue, but I don't think it will work with the Mexico City WS at the same time.
