### PR TITLE
build: fix gh-pages build

### DIFF
--- a/.github/workflows/deploy-static-site.yml
+++ b/.github/workflows/deploy-static-site.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Build Site
         run: npm run build
 
+      - name: nojekyll
+        run: touch ./out/.nojekyll        
+
       - name: Deploy Static Site
         uses: JamesIves/github-pages-deploy-action@v4
         with:


### PR DESCRIPTION
GH pages works with a lots of static site generators, one of which is Jekyll... most of these emit files in the root folder, but NextJS differ slightly by emitting files into the `_next/` folder. This change adds a step  to the `deploy-static` pipeline which tells GH pages to ignore the Jekyll build process and serve files within the `_next/` folder.

Content changes:

- N/A

Code changes:

-  add a `.nojekyll` file in the `out` folder  for the build pipeline to tell Git to serve the `_next/*` files instead of assuming they are all in there root folder.
